### PR TITLE
NixOS: Port to NixOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /.vscode
+
+# For nix flakes
+result

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ makepkg -si
 > The `s` flag specifies to install dependecies that are not installed yet on your system but are required by the program.<br />
 > The `i` flag specifies the makepkg program to run the install script after building to install it onto your system!
 
+### NixOS Linux
+**NixOS Users** you can get the pacakge via Nix flakes. 
+1. Add the url to your ```flake.nix``` input
+```nix
+wretch.url = "github:thesillyboi/wretch";
+```
+2. Add ```wretch``` to your ```flake.nix``` output
+```nix
+outputs = { wretch, ... }
+```
+3. Add the pacakge in ```environment.systemPackages```
+```nix
+pkgs.inputs.wretch.packages."${system}".default
+```
+4. Rebuild your configuration with nix flakes enabled.
+
 ## Building and Compiling
    *Ignore the current paragraph if you already have rustup installed and working*
  - Download `rustup` from your package manager or at https://rustup.rs/ if it's not available.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "A simple Fetch CLI program Built with Rust";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  outputs =
+    { self, nixpkgs }:
+    let 
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in{
+      packages.x86_64-linux.default =
+        with import nixpkgs {
+          system = "x86_64-linux";
+        };
+        pkgs.rustPlatform.buildRustPackage rec {
+          pname = "wretch";
+          version = "nightly";
+
+          src = self;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs;[
+            cargo
+            rustc
+            pkgs.pkg-config
+            git
+          ];
+        };
+    };
+}
+


### PR DESCRIPTION
### About
Added a nix flake to make the package available for NixOS. 

### Change
1. Added ```flake.nix```, for NixOS
2. ```flake.lock``` is automatically generated
3. Added install instructions for NixOS