### PR TITLE
Prefer os-release id/id_like using long_os_version() as fallback for os name

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -1,6 +1,5 @@
 use colored::{Colorize, ColoredString}; // Import the Colorize trait and ColoredString struct from colored
 pub fn ascii_art(os_ascii_name: &str) -> ([ColoredString; 8], bool) { // Function to Select an ASCII art based on the OS or parameter
-    println!("{}", os_ascii_name);
     let mut retval: [ColoredString; 8] = Default::default(); // Initialize an array of ColoredString with 8 elements
     let mut is_generic = false;
     if os_ascii_name.contains("arch"){ // if the OS version contains "arch"(meant to be used for arch linux)


### PR DESCRIPTION
### About
Modified ascii_name() fn and added new fn get_os_name() to try get os id for os logo and then os id_like using long_os_version() as a fallback in attempt to not use generic tux or computer screen like for example now endeavouros will show arch logo as id_like is set to arch as its arch based while for systems without os_release file it will use long_os_version()
From my tests on my system and a Debian docker container it works fine but may include some unknown bugs.
I'm [@gizzy](https://hackclub.slack.com/team/U08D3AY7BG8) in the HackClub slack.
Changes

- Made get_os_name() fn to pull id and id_like from /etc/os-release
- Modified ascii_name() fn to use id or id_like depending on if id is generic linux tux or computer screen and using long_os_version() as a fallback for systems missing /etc/os-release such as windows machines
- Modified ascii_name() fn to also cache the os name so it doesn't go through whole process when called again
- Modified ascii.rs to receive os_ascii_name as string instead of calling ascii_name() fn itself 
- Added new bool to ascii.rs to be used to see if generic logo
- Modified os_ascii used for printing ascii art to only pull art array from ascii.rs not the bool
- Modified println! for "System name" to return "Unknown" if system name is missing to avoid crash when i was testing with removing /etc/os-release to trigger the fallback