### PR TITLE
Nix: Update Nix flakes to include all available architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ makepkg -si
 > The `s` flag specifies to install dependecies that are not installed yet on your system but are required by the program.<br />
 > The `i` flag specifies the makepkg program to run the install script after building to install it onto your system!
 
-### NixOS Linux
-**NixOS Users** you can get the pacakge via Nix flakes. 
+### Nix (Linux and MacOS)
+**Nix users** you can get the pacakge via Nix flakes. 
 1. Add the url to your ```flake.nix``` input
 ```nix
 wretch.url = "github:thesillyboi/wretch";

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ wretch.url = "github:thesillyboi/wretch";
 ```
 2. Add the pacakge in ```environment.systemPackages```
 ```nix
-pkgs.inputs.wretch.packages."${system}".default
+inputs.wretch.packages."${system}".default
 ```
 3. Rebuild your configuration with nix flakes enabled.
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ wretch.url = "github:thesillyboi/wretch";
 pkgs.inputs.wretch.packages."${system}".default
 ```
 3. Rebuild your configuration with nix flakes enabled.
-> [!TIPS]
+> [!TIP]
 > Update the application using:
 > ```nix
 > nix flake update wretch

--- a/README.md
+++ b/README.md
@@ -40,15 +40,16 @@ makepkg -si
 ```nix
 wretch.url = "github:thesillyboi/wretch";
 ```
-2. Add ```wretch``` to your ```flake.nix``` output
-```nix
-outputs = { wretch, ... }
-```
-3. Add the pacakge in ```environment.systemPackages```
+2. Add the pacakge in ```environment.systemPackages```
 ```nix
 pkgs.inputs.wretch.packages."${system}".default
 ```
-4. Rebuild your configuration with nix flakes enabled.
+3. Rebuild your configuration with nix flakes enabled.
+> [!TIPS]
+> Update the application using:
+> ```nix
+> nix flake update wretch
+> ```
 
 ## Building and Compiling
    *Ignore the current paragraph if you already have rustup installed and working*

--- a/flake.nix
+++ b/flake.nix
@@ -3,30 +3,40 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
   outputs =
     { self, nixpkgs }:
-    let 
-      system = "x86_64-linux";
-      pkgs = nixpkgs.legacyPackages.${system};
-    in{
-      packages.x86_64-linux.default =
-        with import nixpkgs {
-          system = "x86_64-linux";
-        };
-        pkgs.rustPlatform.buildRustPackage rec {
-          pname = "wretch";
-          version = "nightly";
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage rec {
+            pname = "wretch";
+            version = "nightly";
 
-          src = self;
+            src = self;
 
-          cargoLock = {
-            lockFile = ./Cargo.lock;
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+            };
+
+            nativeBuildInputs = with pkgs; [
+              cargo
+              rustc
+              pkgs.pkg-config
+              git
+            ];
           };
-
-          nativeBuildInputs = with pkgs;[
-            cargo
-            rustc
-            pkgs.pkg-config
-            git
-          ];
-        };
+        }
+      );
     };
 }


### PR DESCRIPTION
**Change**
- Added ```aarch64-linux```, ```x86_64-darwin```, and ```aarch64-darwin``` architecture
- ReadMe: Simplified and clarified the Nix install instruction section